### PR TITLE
add func and tests

### DIFF
--- a/sqlwhat_ext.py
+++ b/sqlwhat_ext.py
@@ -52,6 +52,24 @@ def check_result_tsql(state, msg="Incorrect result."):
 
     return state
 
+@state_dec
+def pof(state, msg='Your submission is incorrect.'):
+    """High level function wrapping other SCTs, giving a pass or fail result."""
+    stu_res = state.student_result
+    sol_res = state.solution_result
+
+    # empty test
+    test_has_columns(state, msg=msg)
+    # row test
+    test_nrows(state, msg=msg)
+    # column tests
+    child = _sort_columns_indiv(state)
+
+    for k in sol_res:
+        test_column(child, k, msg=msg, match = 'any')
+
+    return state
+
 def _sort_columns_indiv(state):
     tiny_none = TinyNone()
     sorted_columns = lambda res: {k: sorted(col, key = lambda el: el or tiny_none) for k, col in res.items()}

--- a/sqlwhat_ext.py
+++ b/sqlwhat_ext.py
@@ -55,19 +55,7 @@ def check_result_tsql(state, msg="Incorrect result."):
 @state_dec
 def pof(state, msg='Your submission is incorrect.'):
     """High level function wrapping other SCTs, giving a pass or fail result."""
-    stu_res = state.student_result
-    sol_res = state.solution_result
-
-    # empty test
-    test_has_columns(state, msg=msg)
-    # row test
-    test_nrows(state, msg=msg)
-    # column tests
-    child = _sort_columns_indiv(state)
-
-    for k in sol_res:
-        test_column(child, k, msg=msg, match = 'any')
-
+    Ex(state).test_correct(check_result_tsql(), fail(msg=msg))
     return state
 
 def _sort_columns_indiv(state):

--- a/tests/test_check_result2.py
+++ b/tests/test_check_result2.py
@@ -13,7 +13,7 @@ def prepare_state(sol_result, stu_result):
         solution_code = "",
         reporter = Reporter(),
         # args below should be ignored
-        pre_exercise_code = "", 
+        pre_exercise_code = "",
         student_result = stu_result, solution_result = sol_result,
         student_conn = None, solution_conn = None,
         ast_dispatcher = dispatcher)

--- a/tests/test_pof.py
+++ b/tests/test_pof.py
@@ -1,0 +1,48 @@
+from sqlwhat.Reporter import Reporter
+from sqlwhat.State import State
+from sqlwhat.selectors import Dispatcher
+from sqlwhat.Test import TestFail as TF
+
+import pytest
+
+def prepare_state(sol_result, stu_result):
+    dispatcher = Dispatcher.from_dialect('postgresql')
+
+    return State(
+        student_code = "",
+        solution_code = "",
+        reporter = Reporter(),
+        # args below should be ignored
+        pre_exercise_code = "",
+        student_result = stu_result, solution_result = sol_result,
+        student_conn = None, solution_conn = None,
+        ast_dispatcher = dispatcher)
+
+
+from sqlwhat.sct_syntax import Ex
+from sqlwhat_ext import pof
+
+def test_pof_tsql_chain():
+    state = prepare_state({'a': [1,2,3]}, {'a': [1,2,3]})
+    Ex(state) >> pof()
+
+@pytest.mark.parametrize('sol_res, stu_res', [        # pass cases where...
+    ( {'a': [1,2,3]}, {'a': [1,2,3]} ),              # identical
+    ( {'a': [1,2,3]}, {'b': [1,2,3]} ),              # diff colnames
+    ( {'a': [1,2,3]}, {'b': [3,2,1]} ),              # diff colnames + reordered
+    ( {'a': [1]}    , {'a': [1], 'b': [2]} )         # extra cols in student result
+    ])
+
+def test_check_result_tsql_pass(sol_res, stu_res):
+    state = prepare_state(sol_res, stu_res)
+    pof(state)
+
+@pytest.mark.parametrize('sol_res, stu_res', [        # fail cases where...
+    ( {'a': [1,2,3]}, {'a': [1,2]} ),                # too few rows
+    ( {'a': [1,2,3]}, {'a': [1,2,2]} )               # values mismatch
+    ])
+
+def test_check_result_tsql_match_fail(sol_res, stu_res):
+    state = prepare_state(sol_res, stu_res)
+    with pytest.raises(TF):
+        pof(state)

--- a/tests/test_pof.py
+++ b/tests/test_pof.py
@@ -18,11 +18,10 @@ def prepare_state(sol_result, stu_result):
         student_conn = None, solution_conn = None,
         ast_dispatcher = dispatcher)
 
-
 from sqlwhat.sct_syntax import Ex
 from sqlwhat_ext import pof
 
-def test_pof_tsql_chain():
+def test_pof_chain():
     state = prepare_state({'a': [1,2,3]}, {'a': [1,2,3]})
     Ex(state) >> pof()
 
@@ -33,7 +32,7 @@ def test_pof_tsql_chain():
     ( {'a': [1]}    , {'a': [1], 'b': [2]} )         # extra cols in student result
     ])
 
-def test_check_result_tsql_pass(sol_res, stu_res):
+def test_pof_pass(sol_res, stu_res):
     state = prepare_state(sol_res, stu_res)
     pof(state)
 
@@ -42,7 +41,7 @@ def test_check_result_tsql_pass(sol_res, stu_res):
     ( {'a': [1,2,3]}, {'a': [1,2,2]} )               # values mismatch
     ])
 
-def test_check_result_tsql_match_fail(sol_res, stu_res):
+def test_check_pof_match_fail(sol_res, stu_res):
     state = prepare_state(sol_res, stu_res)
     with pytest.raises(TF):
         pof(state)


### PR DESCRIPTION
This PR just adds a `pof()` (pass or fail) function which reports `'Your submission is incorrect.'` for any student submission failures. 

It overrides stuff like `'column x is not in your solution'`. 

Probably just a temporary mocking function for the Transact-SQL exam lab, as I'm not sure what way submission for that will actually work. 

The `colin-add-pof` branch is currently referenced [here](https://github.com/datacamp/courses-msft-tsql-lab/blob/master/requirements.sh).

cc @ncarchedi 